### PR TITLE
Turn on --hostonly mode

### DIFF
--- a/bin/initoverlayfs-install
+++ b/bin/initoverlayfs-install
@@ -69,7 +69,7 @@ fi
 initoverlayfs_conf="/etc/initoverlayfs.conf"
 if ! [ -e "$initoverlayfs_conf" ]; then
   boot_partition=$(cat /etc/fstab | grep "/boot.*ext4" | awk '{print $1}')
-  echo -e "bootfs $boot_partition\nbootfstype ext4\ninitoverlayfs_builder dracut -N -f -v -M --reproducible -o \"initoverlayfs\"\ninitrd_builder dracut -N -f -v -M --reproducible -m \"kernel-modules udev-rules initoverlayfs\" -o \"bash systemd systemd-initrd i18n kernel-modules-extra rootfs-block dracut-systemd usrmount base fs-lib microcode_ctl-fw_dir_override shutdown nss-softok\"\nudev_trigger udevadm trigger --type=devices --action=add --subsystem-match=module --subsystem-match=block --subsystem-match=virtio --subsystem-match=pci --subsystem-match=nvme\n" > $initoverlayfs_conf
+  echo -e "bootfs $boot_partition\nbootfstype ext4\ninitoverlayfs_builder dracut -H -f -v -M --reproducible -o \"initoverlayfs\"\ninitrd_builder dracut -H -f -v -M --reproducible -m \"kernel-modules udev-rules initoverlayfs\" -o \"bash systemd systemd-initrd i18n kernel-modules-extra rootfs-block dracut-systemd usrmount base fs-lib microcode_ctl-fw_dir_override shutdown nss-softokn\"\nudev_trigger udevadm trigger --type=devices --action=add --subsystem-match=module --subsystem-match=block --subsystem-match=virtio --subsystem-match=pci --subsystem-match=nvme\n" > $initoverlayfs_conf
 fi
 
 no_kern=""


### PR DESCRIPTION
We only want to include kernel modules from the host. Although we may want to run --no-hostonly mode in build systems as we may not know the hardware of the host we are running on.

Also fixed a small typo nss-softokn.

Reported-by: Douglas Landgraf <dougsland@gmail.com>